### PR TITLE
Add -r timeout[:interval] option to atf-check.

### DIFF
--- a/atf-sh/atf-check.1
+++ b/atf-sh/atf-check.1
@@ -22,7 +22,7 @@
 .\" IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 .\" OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 .\" IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.Dd October 5, 2014
+.Dd June 21, 2020
 .Dt ATF-CHECK 1
 .Os
 .Sh NAME
@@ -120,6 +120,13 @@ as a shell command line, executing it with the system shell defined by
 .Va ATF_SHELL .
 You should avoid using this flag if at all possible to prevent shell quoting
 issues.
+.It Fl r Ar timeout[:interval]
+Repeats failed checks until the
+.Ar timeout
+(in seconds) expires. If unspecified, the default
+.Ar interval
+(in milliseconds) is 50 ms.
+This can be used to wait for an expected update to the contents of a file.
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width ATFXSHELLXX -compact
@@ -157,6 +164,11 @@ atf_check -s signal:sigsegv my_program
 
 # Combined checks
 atf_check -o match:foo -o not-match:bar echo foo baz
+
+# Wait 5 seconds for a line to show up in a file
+( sleep 2 ; echo "testing 123" > $test_path ) &
+atf-check -o ignore -e ignore -s exit:0 -r 5 \e
+    grep "testing 123" $test_path
 .Ed
 .Sh SEE ALSO
 .Xr atf-sh 1

--- a/atf-sh/atf-check.cpp
+++ b/atf-sh/atf-check.cpp
@@ -29,6 +29,7 @@ extern "C" {
 
 #include <limits.h>
 #include <signal.h>
+#include <stdint.h>
 #include <unistd.h>
 }
 
@@ -52,6 +53,10 @@ extern "C" {
 #include "atf-c++/detail/process.hpp"
 #include "atf-c++/detail/sanity.hpp"
 #include "atf-c++/detail/text.hpp"
+
+static const useconds_t seconds_in_useconds = (1000 * 1000);
+static const useconds_t mseconds_in_useconds = 1000;
+static const useconds_t useconds_in_nseconds = 1000;
 
 // ------------------------------------------------------------------------
 // Auxiliary functions.
@@ -161,6 +166,33 @@ public:
 };
 
 } // anonymous namespace
+
+static useconds_t
+get_monotonic_useconds(void)
+{
+    struct timespec ts;
+    useconds_t res;
+    int rc;
+
+    rc = clock_gettime(CLOCK_MONOTONIC, &ts);
+    if (rc != 0)
+        throw std::runtime_error("clock_gettime: " +
+            std::string(strerror(errno)));
+
+    res = ts.tv_sec * seconds_in_useconds;
+    res += ts.tv_nsec / useconds_in_nseconds;
+    return res;
+}
+
+static bool
+timo_expired(useconds_t timeout)
+{
+
+    if (get_monotonic_useconds() >= timeout)
+        return true;
+    return false;
+}
+
 
 static int
 parse_exit_code(const std::string& str)
@@ -304,6 +336,62 @@ parse_output_check_arg(const std::string& arg)
         throw atf::application::usage_error("Invalid output checker");
 
     return output_check(type, negated, arg.substr(delimiter + 1));
+}
+
+static void
+parse_repeat_check_arg(const std::string& arg, useconds_t *m_timo,
+    useconds_t *m_interval)
+{
+    const std::string::size_type delimiter = arg.find(':');
+    const bool has_interval = (delimiter != std::string::npos);
+    const std::string timo_str = arg.substr(0, delimiter);
+
+    long l;
+    char *end;
+
+    // There is no reason this couldn't be a non-integer number of seconds,
+    // this was just easy to do for now.
+    errno = 0;
+    l = strtol(timo_str.c_str(), &end, 10);
+    if (errno == ERANGE)
+        throw atf::application::usage_error("Bogus timeout in seconds");
+    else if (errno != 0)
+        throw atf::application::usage_error("Timeout must be a number");
+
+    if (*end != 0)
+        throw atf::application::usage_error("Timeout must be a number");
+
+    *m_timo = get_monotonic_useconds() + (l * seconds_in_useconds);
+    // 50 milliseconds is chosen arbitrarily.  There is a tradeoff between
+    // longer and shorter poll times.  A shorter poll time makes for faster
+    // tests.  A longer poll time makes for lower CPU overhead for the polled
+    // operation.  50ms is chosen with these tradeoffs in mind: on
+    // microcontrollers, the hope is that we can still avoid meaningful CPU use
+    // with a small test every 50ms.  And on typical fast x86 hardware, our
+    // tests can be much more precise with time wasted than they typically are
+    // without this feature.
+    *m_interval = 50 * mseconds_in_useconds;
+
+    if (!has_interval)
+        return;
+
+    const std::string intv_str = arg.substr(delimiter + 1, std::string::npos);
+
+    // Same -- this could be non-integer milliseconds.
+    errno = 0;
+    l = strtol(intv_str.c_str(), &end, 10);
+    if (errno == ERANGE)
+        throw atf::application::usage_error(
+            "Bogus repeat interval in milliseconds");
+    else if (errno != 0)
+        throw atf::application::usage_error(
+            "Repeat interval must be a number");
+
+    if (*end != 0)
+        throw atf::application::usage_error(
+            "Repeat interval must be a number");
+
+    *m_interval = l * mseconds_in_useconds;
 }
 
 static
@@ -693,7 +781,11 @@ run_output_checks(const std::vector< output_check >& checks,
 namespace {
 
 class atf_check : public atf::application::app {
+    bool m_rflag;
     bool m_xflag;
+
+    useconds_t m_timo;
+    useconds_t m_interval;
 
     std::vector< status_check > m_status_checks;
     std::vector< output_check > m_stdout_checks;
@@ -721,6 +813,7 @@ const char* atf_check::m_description =
 
 atf_check::atf_check(void) :
     app(m_description, "atf-check(1)"),
+    m_rflag(false),
     m_xflag(false)
 {
 }
@@ -764,6 +857,8 @@ atf_check::specific_options(void)
     opts.insert(option('e', "action:arg", "Handle stderr. Action must be "
                 "one of: empty ignore file:<path> inline:<val> match:regexp "
                 "save:<path>"));
+    opts.insert(option('r', "timeout[:interval]", "Repeat failed check until "
+                "the timeout expires."));
     opts.insert(option('x', "", "Execute command as a shell command"));
 
     return opts;
@@ -785,6 +880,11 @@ atf_check::process_option(int ch, const char* arg)
         m_stderr_checks.push_back(parse_output_check_arg(arg));
         break;
 
+    case 'r':
+        m_rflag = true;
+        parse_repeat_check_arg(arg, &m_timo, &m_interval);
+        break;
+
     case 'x':
         m_xflag = true;
         break;
@@ -802,9 +902,6 @@ atf_check::main(void)
 
     int status = EXIT_FAILURE;
 
-    std::auto_ptr< atf::check::check_result > r =
-        m_xflag ? execute_with_shell(m_argv) : execute(m_argv);
-
     if (m_status_checks.empty())
         m_status_checks.push_back(status_check(sc_exit, false, EXIT_SUCCESS));
     else if (m_status_checks.size() > 1) {
@@ -817,12 +914,23 @@ atf_check::main(void)
     if (m_stderr_checks.empty())
         m_stderr_checks.push_back(output_check(oc_empty, false, ""));
 
-    if ((run_status_checks(m_status_checks, *r) == false) ||
-        (run_output_checks(*r, "stderr") == false) ||
-        (run_output_checks(*r, "stdout") == false))
-        status = EXIT_FAILURE;
-    else
-        status = EXIT_SUCCESS;
+    do {
+        std::auto_ptr< atf::check::check_result > r =
+            m_xflag ? execute_with_shell(m_argv) : execute(m_argv);
+
+        if ((run_status_checks(m_status_checks, *r) == false) ||
+            (run_output_checks(*r, "stderr") == false) ||
+            (run_output_checks(*r, "stdout") == false))
+            status = EXIT_FAILURE;
+        else
+            status = EXIT_SUCCESS;
+
+        if (m_rflag && status == EXIT_FAILURE) {
+            if (timo_expired(m_timo))
+                break;
+            usleep(m_interval);
+        }
+    } while (m_rflag && status == EXIT_FAILURE);
 
     return status;
 }


### PR DESCRIPTION
This allows repeatedly polling some command until it succeeds, to some
timeout limit.