### PR TITLE
Fix long line

### DIFF
--- a/atf-c++/atf-c++.3
+++ b/atf-c++/atf-c++.3
@@ -403,8 +403,8 @@ in the collection.
 takes the name of an exception and a statement and raises a failure if
 the statement does not throw the specified exception.
 .Fn ATF_REQUIRE_THROW_RE
-takes the name of an exception, a regular expression and a statement, and raises a
-failure if the statement does not throw the specified exception and if the
+takes the name of an exception, a regular expression and a statement, and raises
+a failure if the statement does not throw the specified exception and if the
 message of the exception does not match the regular expression.
 .Pp
 .Fn ATF_CHECK_ERRNO


### PR DESCRIPTION
Per ./admin/check-style.sh:
atf-c++/atf-c++.3[406]: Line too long to fit on screen

Sponsored by:	The FreeBSD Foundation