### PR TITLE
atf-sh: Avoid spawning subprocesses in _atf_normalize()

### DIFF
--- a/atf-sh/libatf-sh.subr
+++ b/atf-sh/libatf-sh.subr
@@ -553,7 +553,18 @@ _atf_list_tcs()
 #
 _atf_normalize()
 {
-    echo ${1} | tr .- __
+    # Check if the string contains any of the forbidden characters using
+    # POSIX parameter expansion (the ${var//} string substitution is
+    # unfortunately not supported in POSIX sh) and only use tr(1) then.
+    # tr(1) is generally not a builtin, so doing the substring check first
+    # avoids unnecessary fork()+execve() calls. As this function is called
+    # many times in each test script startup, those overheads add up
+    # (especially when running on emulated platforms such as QEMU).
+    if [ "${1#*[.-]}" != "$1" ]; then
+        echo "$1" | tr .- __
+    else
+        echo "$1"
+    fi
 }
 
 #


### PR DESCRIPTION
atf-sh: Avoid spawning subprocesses in _atf_normalize()

I have been trying to speed up the time it takes to run the testsuite for
CheriBSD on QEMU RISC-V (originally 22 hours). One of the slowest tests is
the pfctl test since ever single invocation of it spends ~90 seconds
generating the list of available tests (even when running only one test).
And this is after the change in r365708 that removes ~200 calls to
atf_get_srcdir(). Looking at truss output it turns out that using atf-sh
results in many tr processes being spawned to perform string substitution.

The _atf_normalize() function tries to remove characters that are not valid
in shell variable names by replacing . and - with _. However, most strings
passed to the function don't contain those characters, so we unnecessarily
fork() a new tr processes (which adds up to a significant slowdown).
With this change we only call tr if the variable contains one of the
illegal characters rather than unconditionally.

Ideally we would do this substitution using only shell builtins, but
unfortunately the string substitution syntax ${var//} is not supported by
POSIX sh and I am not aware of any alternatives.

Basic time measurements on CHERI-QEMU RISC-V usng
`/usr/bin/time /usr/tests/sbin/pfctl_test -l > /dev/null`:
Before:
       `90.68 real        89.99 user         0.10 sys`
After:
       `14.50 real        14.31 user         0.10 sys`

I.e. 85% of the time was being spent in these tr invocations!

truss -cf before:
```
syscall                     seconds   calls  errors
fork                  453.330532000    2371       0
cap_enter               0.247944000     633       0
cap_ioctls_limit        0.761099000    1899       0
vfork                   0.421971000       2       0
getegid                 0.000342000       1       0
getgid                  0.000358000       1       0
getuid                  0.000324000       1       0
getppid                 0.000589000       1       0
geteuid                 0.000631000       2       0
getpid                  0.000328000       1       0
issetugid               0.450306000    1270       0
write                   0.415779000     634       0
__sysctl                0.280936000     634       0
sigprocmask             2.543827000    6340       0
readlink                0.317952000     635     635
read                    1.319873000    2532       0
pread                   0.327678000     634       0
open                    1.399164000    2536     634
munmap                  0.301268000     634       0
mprotect                0.566142000    1268       0
mmap                    7.117084000    8876       0
fstat                   1.326981000    3168       0
dup2                    0.954023000    2373       0
close                   4.496506000    9979       0
clock_gettime           0.740010000    1902       0
cap_rights_limit        0.770141000    1899       0
cap_fcntls_limit        0.695135000    1899       0
                      ------------- ------- -------
                      478.786923000   52125    1269

```
After:
```
syscall                     seconds   calls  errors
fork                   24.675445000    1107       0
cap_enter               0.000340000       1       0
cap_ioctls_limit        0.001009000       3       0
vfork                   0.228345000       1       0
getegid                 0.000318000       1       0
getgid                  0.000323000       1       0
getuid                  0.000345000       1       0
getppid                 0.000329000       1       0
geteuid                 0.000726000       2       0
getpid                  0.000335000       1       0
issetugid               0.001554000       4       0
write                   0.000539000       1       0
__sysctl                0.000369000       1       0
sigprocmask             0.003684000      10       0
readlink                0.000440000       1       1
read                    0.001318000       2       0
pread                   0.000556000       1       0
open                    0.002250000       4       1
munmap                  0.000524000       1       0
mprotect                0.000767000       2       0
mmap                    0.011109000      14       0
fstat                   0.001743000       4       0
dup2                    0.398638000    1108       0
close                   1.996684000    4916       0
clock_gettime           0.001047000       3       0
cap_rights_limit        0.001170000       3       0
cap_fcntls_limit        0.000930000       3       0
                      ------------- ------- -------
                       27.330837000    7197       2
```
