### PR TITLE
atf-sh: Avoid an unnecessary fork() on startup

### DIFF
--- a/atf-sh/libatf-sh.subr
+++ b/atf-sh/libatf-sh.subr
@@ -751,7 +751,7 @@ main()
             ;;
         esac
     done
-    shift `expr ${OPTIND} - 1`
+    shift $((OPTIND - 1))
 
     case ${Source_Dir} in
         /*)


### PR DESCRIPTION
`expr ${OPTIND} - 1` can be replaced with $((OPTIND - 1)) to avoid spawning
a new processes. While it's unlikely to make much of a performance
difference for a single execution, it happens once for ever test case so
it will add up for a full testsuite run.