### PR TITLE
Fix make distcheck warning that is causing CI to fail

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ task:
   install_script:
     - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
     - pkg upgrade -y
-    - pkg install -y autoconf automake libtool
+    - pkg install -y autoconf automake libtool kyua
   script:
     - env JUNIT_OUTPUT=$(pwd)/test-results.xml ./admin/travis-build.sh
   always:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,4 +18,9 @@ task:
     - pkg upgrade -y
     - pkg install -y autoconf automake libtool
   script:
-    - ./admin/travis-build.sh
+    - env JUNIT_OUTPUT=$(pwd)/test-results.xml ./admin/travis-build.sh
+  always:
+    junit_artifacts:
+      path: "test-results.xml"
+      type: text/xml
+      format: junit

--- a/Makefile.am
+++ b/Makefile.am
@@ -74,8 +74,18 @@ PHONY_TARGETS += installcheck-kyua
 if HAVE_KYUA
 INSTALLCHECK_TARGETS += installcheck-kyua
 installcheck-kyua:
+	set +e; cd $(pkgtestsdir) && $(TESTS_ENVIRONMENT) \
+	    $(KYUA) --config='$(KYUA_TEST_CONFIG_FILE)' test; \
+	ret=$$?; \
+	echo $$ret; \
+	if [ -n "$$JUNIT_OUTPUT" ]; then \
+	    cd $(pkgtestsdir) && $(TESTS_ENVIRONMENT) \
+		    $(KYUA) --config='$(KYUA_TEST_CONFIG_FILE)' \
+		    report-junit --output="$$JUNIT_OUTPUT"; \
+	fi; \
 	cd $(pkgtestsdir) && $(TESTS_ENVIRONMENT) \
-	    $(KYUA) --config='$(KYUA_TEST_CONFIG_FILE)' test
+		$(KYUA) --config='$(KYUA_TEST_CONFIG_FILE)' report --verbose; \
+	exit $$ret
 endif
 
 installcheck-local: $(INSTALLCHECK_TARGETS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -82,6 +82,7 @@ installcheck-kyua:
 	    cd $(pkgtestsdir) && $(TESTS_ENVIRONMENT) \
 		    $(KYUA) --config='$(KYUA_TEST_CONFIG_FILE)' \
 		    report-junit --output="$$JUNIT_OUTPUT"; \
+		    sed -i '' 's/encoding="iso-8859-1"/econding="utf-8"/' "$$JUNIT_OUTPUT"; \
 	fi; \
 	cd $(pkgtestsdir) && $(TESTS_ENVIRONMENT) \
 		$(KYUA) --config='$(KYUA_TEST_CONFIG_FILE)' report --verbose; \

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -65,6 +65,7 @@ else
     make distcheck DISTCHECK_CONFIGURE_FLAGS="${f}" || ret=${?}
 fi
 if [ ${ret} -ne 0 ]; then
+    find .
     cat atf-*/_build/config.log || true
     exit ${ret}
 fi

--- a/atf-sh/atf-check.1
+++ b/atf-sh/atf-check.1
@@ -123,7 +123,8 @@ issues.
 .It Fl r Ar timeout[:interval]
 Repeats failed checks until the
 .Ar timeout
-(in seconds) expires. If unspecified, the default
+(in seconds) expires.
+If unspecified, the default
 .Ar interval
 (in milliseconds) is 50 ms.
 This can be used to wait for an expected update to the contents of a file.


### PR DESCRIPTION
atf-sh/atf-check.1[126]: Sentence does not start on new line