### PR TITLE
Fix all of the failing tests

### DIFF
--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -65,8 +65,7 @@ else
     make distcheck DISTCHECK_CONFIGURE_FLAGS="${f}" || ret=${?}
 fi
 if [ ${ret} -ne 0 ]; then
-    find .
-    cat atf-*/_build/config.log || true
+    cat atf-*/_build/sub/config.log || true
     exit ${ret}
 fi
 

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -46,11 +46,17 @@ archflags=
 [ "${ARCH?}" != i386 ] || archflags=-m32
 
 f=
-f="${f} ATF_BUILD_CC='${CC} ${archflags}'"
-f="${f} ATF_BUILD_CXX='${CXX} ${archflags}'"
-f="${f} CFLAGS='${archflags}'"
-f="${f} CXXFLAGS='${archflags}'"
-f="${f} LDFLAGS='${archflags}'"
+
+if [ -n "${archflags}" ]; then
+    CC=${CC-"cc"}
+    CXX=${CXX-"c++"}
+
+    f="${f} ATF_BUILD_CC='${CC} ${archflags}'"
+    f="${f} ATF_BUILD_CXX='${CXX} ${archflags}'"
+    f="${f} CFLAGS='${archflags}'"
+    f="${f} CXXFLAGS='${archflags}'"
+    f="${f} LDFLAGS='${archflags}'"
+fi
 
 if [ "${AS_ROOT:-no}" = yes ]; then
     cat >root-kyua.conf <<EOF

--- a/atf-c++/tests.hpp
+++ b/atf-c++/tests.hpp
@@ -73,7 +73,7 @@ class tc {
     tc(const tc&);
     tc& operator=(const tc&);
 
-    std::auto_ptr< tc_impl > pimpl;
+    std::unique_ptr< tc_impl > pimpl;
 
 protected:
     virtual void head(void);

--- a/atf-c++/utils.cpp
+++ b/atf-c++/utils.cpp
@@ -70,6 +70,13 @@ atf::utils::fork(void)
     return atf_utils_fork();
 }
 
+void
+atf::utils::reset_resultsfile(void)
+{
+
+    atf_utils_reset_resultsfile();
+}
+
 bool
 atf::utils::grep_file(const std::string& regex, const std::string& path)
 {

--- a/atf-c++/utils.hpp
+++ b/atf-c++/utils.hpp
@@ -41,6 +41,7 @@ void copy_file(const std::string&, const std::string&);
 void create_file(const std::string&, const std::string&);
 bool file_exists(const std::string&);
 pid_t fork(void);
+void reset_resultsfile(void);
 bool grep_file(const std::string&, const std::string&);
 bool grep_string(const std::string&, const std::string&);
 void redirect(const int, const std::string&);

--- a/atf-c++/utils_test.cpp
+++ b/atf-c++/utils_test.cpp
@@ -335,6 +335,7 @@ fork_and_wait(const int exitstatus, const char* expout, const char* experr)
         std::cerr << "Some error\n";
         exit(123);
     }
+    atf::utils::reset_resultsfile();
     atf::utils::wait(pid, exitstatus, expout, experr);
     exit(EXIT_SUCCESS);
 }

--- a/atf-c/tc.c
+++ b/atf-c/tc.c
@@ -252,7 +252,6 @@ create_resfile(struct context *ctx, const char *result, const int arg,
     atf_error_t err;
 
     err = write_resfile(ctx->resfilefd, result, arg, reason);
-    context_close_resfile(ctx);
 
     if (reason != NULL)
         atf_dynstr_fini(reason);
@@ -312,6 +311,7 @@ expected_failure(struct context *ctx, atf_dynstr_t *reason)
     check_fatal_error(atf_dynstr_prepend_fmt(reason, "%s: ",
         atf_dynstr_cstring(&ctx->expect_reason)));
     create_resfile(ctx, "expected_failure", -1, reason);
+    context_close_resfile(ctx);
     exit(EXIT_SUCCESS);
 }
 
@@ -322,6 +322,7 @@ fail_requirement(struct context *ctx, atf_dynstr_t *reason)
         expected_failure(ctx, reason);
     } else if (ctx->expect == EXPECT_PASS) {
         create_resfile(ctx, "failed", -1, reason);
+        context_close_resfile(ctx);
         exit(EXIT_FAILURE);
     } else {
         error_in_expect(ctx, "Test case raised a failure but was not "
@@ -357,6 +358,7 @@ pass(struct context *ctx)
             "a pass instead");
     } else if (ctx->expect == EXPECT_PASS) {
         create_resfile(ctx, "passed", -1, NULL);
+        context_close_resfile(ctx);
         exit(EXIT_SUCCESS);
     } else {
         error_in_expect(ctx, "Test case asked to explicitly pass but was "
@@ -370,6 +372,7 @@ skip(struct context *ctx, atf_dynstr_t *reason)
 {
     if (ctx->expect == EXPECT_PASS) {
         create_resfile(ctx, "skipped", -1, reason);
+        context_close_resfile(ctx);
         exit(EXIT_SUCCESS);
     } else {
         error_in_expect(ctx, "Can only skip a test case when running in "

--- a/atf-c/tc.c
+++ b/atf-c/tc.c
@@ -251,6 +251,17 @@ create_resfile(struct context *ctx, const char *result, const int arg,
 {
     atf_error_t err;
 
+    /*
+     * We'll attempt to truncate the results file, but only if it's not pointed
+     * at stdout/stderr.  We could just blindly ftruncate() here, but it may
+     * be that stdout/stderr have been redirected to a file that we want to
+     * validate expectations on, for example.  Kyua will want the truncation,
+     * but it will also redirect the results directly to some file and we'll
+     * have no issue here.
+     */
+    if (ctx->resfilefd != STDOUT_FILENO && ctx->resfilefd != STDERR_FILENO &&
+        ftruncate(ctx->resfilefd, 0) != -1)
+        lseek(ctx->resfilefd, 0, SEEK_SET);
     err = write_resfile(ctx->resfilefd, result, arg, reason);
 
     if (reason != NULL)

--- a/atf-c/tc.c
+++ b/atf-c/tc.c
@@ -106,6 +106,9 @@ static void errno_test(struct context *, const char *, const size_t,
 static atf_error_t check_prog_in_dir(const char *, void *);
 static atf_error_t check_prog(struct context *, const char *);
 
+/* No prototype in header for this one, it's a little sketchy (internal). */
+void atf_tc_set_resultsfile(const char *);
+
 static void
 context_init(struct context *ctx, const atf_tc_t *tc, const char *resfile)
 {
@@ -1022,6 +1025,13 @@ _atf_tc_expect_timeout(struct context *ctx, const char *reason, va_list ap)
     create_resfile(ctx, "expected_timeout", -1, &formatted);
 }
 
+static void
+_atf_tc_set_resultsfile(struct context *ctx, const char *file)
+{
+
+    context_set_resfile(ctx, file);
+}
+
 /* ---------------------------------------------------------------------
  * Free functions.
  * --------------------------------------------------------------------- */
@@ -1242,4 +1252,14 @@ atf_tc_expect_timeout(const char *reason, ...)
     va_start(ap, reason);
     _atf_tc_expect_timeout(&Current, reason, ap);
     va_end(ap);
+}
+
+/* Internal! */
+void
+atf_tc_set_resultsfile(const char *file)
+{
+
+    PRE(Current.tc != NULL);
+
+    _atf_tc_set_resultsfile(&Current, file);
 }

--- a/atf-c/utils.c
+++ b/atf-c/utils.c
@@ -41,6 +41,9 @@
 
 #include "atf-c/detail/dynstr.h"
 
+/* No prototype in header for this one, it's a little sketchy (internal). */
+void atf_tc_set_resultsfile(const char *);
+
 /** Allocate a filename to be used by atf_utils_{fork,wait}.
  *
  * In case of a failure, marks the calling test as failed when in_parent is
@@ -269,6 +272,13 @@ atf_utils_fork(void)
         atf_dynstr_fini(&out_name);
     }
     return pid;
+}
+
+void
+atf_utils_reset_resultsfile(void)
+{
+
+    atf_tc_set_resultsfile("/dev/null");
 }
 
 /** Frees an dynamically-allocated "argv" array.

--- a/atf-c/utils.h
+++ b/atf-c/utils.h
@@ -46,5 +46,6 @@ bool atf_utils_grep_string(const char *, const char *, ...)
 char *atf_utils_readline(int);
 void atf_utils_redirect(const int, const char *);
 void atf_utils_wait(const pid_t, const int, const char *, const char *);
+void atf_utils_reset_resultsfile(void);
 
 #endif /* !defined(ATF_C_UTILS_H) */

--- a/atf-c/utils_test.c
+++ b/atf-c/utils_test.c
@@ -395,6 +395,7 @@ fork_and_wait(const int exitstatus, const char* expout, const char* experr)
         fprintf(stderr, "Some error\n");
         exit(123);
     }
+    atf_utils_reset_resultsfile();
     atf_utils_wait(pid, exitstatus, expout, experr);
     exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
There were a couple high-level issues here that I've fixed in this series; generally the issues were:

- One test compiles a test, gets hit with a warning about auto_ptr being deprecated; no biggie, this is a clear-cut case for unique_ptr

- Some tests fork, fork, do stuff in child and some validation in the parent, then the parent checks whether the middle-fork parent was successful or not. Some of them are supposed to not be successful, and they were being unsuccessful in a way that broke the outer test's results file. I suspect we unmasked this when we started only opening the file on test case init in case the test goes into capability mode, but there's no reason to keep reopening/closing the file AFAICT. Before the file would've been truncated when the outer test observed the inner test's failure.

- Similar issue, but within a single test: we were closing the results file in create_resfile() if it wasn't stdout/stderr, but we may want to write to the result file multiple times... especially in the case of atf_expect_*() being called, we'll write the expectation then write a failure out if we continued until the end. Edit to add: the second write will cause the file to be truncated, but it's at least not been closed on us now.