### PR TITLE
atf-check.1: stop with extraneous quoting

### DIFF
--- a/atf-sh/atf-check.1
+++ b/atf-sh/atf-check.1
@@ -22,7 +22,7 @@
 .\" IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 .\" OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 .\" IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.Dd June 21, 2020
+.Dd February 6, 2021
 .Dt ATF-CHECK 1
 .Os
 .Sh NAME
@@ -150,15 +150,15 @@ instead of executing
 directly:
 .Bd -literal -offset indent
 # Exit code 0, nothing on stdout/stderr
-atf_check 'true'
+atf_check true
 
 # Typical usage if failure is expected
-atf_check -s not-exit:0 'false'
+atf_check -s not-exit:0 false
 
 # Checking stdout/stderr
 echo foobar >expout
 atf_check -o file:expout -e inline:"xx\etyy\en" \e
-    'echo foobar ; printf "xx\etyy\en" >&2'
+    -x 'echo foobar ; printf "xx\etyy\en" >&2'
 
 # Checking for a crash
 atf_check -s signal:sigsegv my_program


### PR DESCRIPTION
Quoted multi-word commands will be passed literally to exec rather than
split on arguments, which will simply not work.  Stop excessive quotes to
make sure we don't mislead folks into thinking they're needed, and slap -x
on the one example that needs it.

This is a follow up to PR #13.