### PR TITLE
Add O_CLOEXEC to all internal open() calls

### DIFF
--- a/atf-c/detail/process.c
+++ b/atf-c/detail/process.c
@@ -347,7 +347,7 @@ child_connect(const stream_prepare_t *sp, int procfd)
         err = safe_dup(sp->m_sb->m_fd, procfd);
     } else if (type == atf_process_stream_type_redirect_path) {
         int aux = open(atf_fs_path_cstring(sp->m_sb->m_path),
-                       O_WRONLY | O_CREAT | O_TRUNC, 0644);
+                       O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
         if (aux == -1)
             err = atf_libc_error(errno, "Could not create %s",
                                  atf_fs_path_cstring(sp->m_sb->m_path));

--- a/atf-c/tc.c
+++ b/atf-c/tc.c
@@ -137,7 +137,7 @@ context_set_resfile(struct context *ctx, const char *resfile)
     else if (strcmp(resfile, "/dev/stderr") == 0)
         ctx->resfilefd = STDERR_FILENO;
     else
-        ctx->resfilefd = open(resfile, O_WRONLY | O_CREAT | O_TRUNC,
+        ctx->resfilefd = open(resfile, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC,
             S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
     if (ctx->resfilefd == -1) {
             err = atf_libc_error(errno,

--- a/atf-c/utils.c
+++ b/atf-c/utils.c
@@ -104,7 +104,7 @@ grep_string(const char *regex, const char *str)
 void
 atf_utils_cat_file(const char *name, const char *prefix)
 {
-    const int fd = open(name, O_RDONLY);
+    const int fd = open(name, O_RDONLY | O_CLOEXEC);
     ATF_REQUIRE_MSG(fd != -1, "Cannot open %s", name);
 
     char buffer[1024];
@@ -145,7 +145,7 @@ atf_utils_cat_file(const char *name, const char *prefix)
 bool
 atf_utils_compare_file(const char *name, const char *contents)
 {
-    const int fd = open(name, O_RDONLY);
+    const int fd = open(name, O_RDONLY | O_CLOEXEC);
     ATF_REQUIRE_MSG(fd != -1, "Cannot open %s", name);
 
     const char *pos = contents;
@@ -173,11 +173,12 @@ atf_utils_compare_file(const char *name, const char *contents)
 void
 atf_utils_copy_file(const char *source, const char *destination)
 {
-    const int input = open(source, O_RDONLY);
+    const int input = open(source, O_RDONLY | O_CLOEXEC);
     ATF_REQUIRE_MSG(input != -1, "Failed to open source file during "
                     "copy (%s)", source);
 
-    const int output = open(destination, O_WRONLY | O_CREAT | O_TRUNC, 0777);
+    const int output = open(destination,
+        O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0777);
     ATF_REQUIRE_MSG(output != -1, "Failed to open destination file during "
                     "copy (%s)", destination);
 
@@ -216,7 +217,7 @@ atf_utils_create_file(const char *name, const char *contents, ...)
     va_end(ap);
     ATF_REQUIRE(!atf_is_error(error));
 
-    const int fd = open(name, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    const int fd = open(name, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
     ATF_REQUIRE_MSG(fd != -1, "Cannot create file %s", name);
     ATF_REQUIRE(write(fd, atf_dynstr_cstring(&formatted),
                       atf_dynstr_length(&formatted)) != -1);
@@ -316,7 +317,7 @@ atf_utils_grep_file(const char *regex, const char *file, ...)
     va_end(ap);
     ATF_REQUIRE(!atf_is_error(error));
 
-    ATF_REQUIRE((fd = open(file, O_RDONLY)) != -1);
+    ATF_REQUIRE((fd = open(file, O_RDONLY | O_CLOEXEC)) != -1);
     bool found = false;
     char *line = NULL;
     while (!found && (line = atf_utils_readline(fd)) != NULL) {
@@ -404,7 +405,8 @@ atf_utils_redirect(const int target_fd, const char *name)
     else if (target_fd == STDERR_FILENO)
         fflush(stderr);
 
-    const int new_fd = open(name, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    const int new_fd = open(name, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC,
+        0644);
     if (new_fd == -1)
         err(EXIT_FAILURE, "Cannot create %s", name);
     if (new_fd != target_fd) {


### PR DESCRIPTION
This should avoid the need for changes such as https://reviews.freebsd.org/D28889