### PR TITLE
Allow skipping a test that is expected to fail

### DIFF
--- a/atf-c/tc.c
+++ b/atf-c/tc.c
@@ -381,15 +381,9 @@ pass(struct context *ctx)
 static void
 skip(struct context *ctx, atf_dynstr_t *reason)
 {
-    if (ctx->expect == EXPECT_PASS) {
-        create_resfile(ctx, "skipped", -1, reason);
-        context_close_resfile(ctx);
-        exit(EXIT_SUCCESS);
-    } else {
-        error_in_expect(ctx, "Can only skip a test case when running in "
-            "expect pass mode");
-    }
-    UNREACHABLE;
+    create_resfile(ctx, "skipped", -1, reason);
+    context_close_resfile(ctx);
+    exit(EXIT_SUCCESS);
 }
 
 /** Formats a failure/skip reason message.


### PR DESCRIPTION
I'm working on a test that will fail due to a kernel bug.  However, it
can't be executed unless certain hardware is present, and I can't check
if the hardware supports the test without running the entire test.  So
it makes sense to set atf_tc_expect_fail in the beginning and later to
atf_tc_skip if the hardware isn't suitable.  But ATF doesn't currently
allow that.